### PR TITLE
PolarityScores optimizations

### DIFF
--- a/benchmark/bench.go
+++ b/benchmark/bench.go
@@ -1,0 +1,35 @@
+package benchmark
+
+import (
+	"encoding/csv"
+	"io"
+	"os"
+)
+
+// LoadTextsFromCSV loads test texts from a CSV file
+func LoadTextsFromCSV(filename string, textColumnIndex int) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var texts []string
+	reader := csv.NewReader(file)
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if textColumnIndex < len(record) {
+			texts = append(texts, record[textColumnIndex])
+		}
+	}
+
+	return texts, nil
+}

--- a/vader_test.go
+++ b/vader_test.go
@@ -1,6 +1,7 @@
 package govader_test
 
 import (
+	"github.com/jonreiter/govader/benchmark"
 	"testing"
 
 	"github.com/jonreiter/govader"
@@ -109,4 +110,15 @@ func BenchmarkPolarityScoresLarge(b *testing.B) {
 	}
 }
 
-// eof
+func BenchmarkFullOnTestData(b *testing.B) {
+	analyzer := govader.NewSentimentIntensityAnalyzer()
+	test_texts, err := benchmark.LoadTextsFromCSV("./benchmark/vader_test.csv", 0)
+	if err != nil {
+		b.Fatalf("Getting test texts failed: %v", err)
+	}
+	b.ResetTimer()
+	for _, text := range test_texts {
+		analyzer.PolarityScores(text)
+	}
+	b.Log(b.Elapsed())
+}


### PR DESCRIPTION
Hello!
Thank you for a great port!

I'm facing some use cases that require more throughput from the library.
So i got into optimizing and by changing the PolarityScores function only i was able to achieve approximate 3x increase in speed (on bigger texts)

I also created a benchmark based on a CSV file that i can also contribute (It contains 10k real world news texts, exactly from my use case)

Before:
<img width="593" alt="Screenshot 2025-04-26 at 11 30 56" src="https://github.com/user-attachments/assets/2d343a30-93bf-47cf-bc0c-d48690a14b04" />

After:
<img width="602" alt="Screenshot 2025-04-26 at 11 45 40" src="https://github.com/user-attachments/assets/88f9b20d-cfab-4044-b2bc-6ed1ca127cef" />
